### PR TITLE
BATIAI-166 - Node group for GitLab runners

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,9 +105,9 @@ module "eks" {
       iam_role_permissions_boundary = var.iam_role_permissions_boundary
       bootstrap_extra_args          = "--kubelet-extra-args '--node-labels=runners=true --register-with-taints=runners=true:NoSchedule'"
       ami_id                        = var.wg_ami_id
-      desired_size                  = 1
-      max_size                      = 1
-      min_size                      = 1
+      desired_size                  = var.runners_desired_size
+      max_size                      = var.runners_max_size
+      min_size                      = var.runners_min_size
       create_security_group         = false
       block_device_mappings = [
         {


### PR DESCRIPTION
## Fixes Issue: [JIRA](https://jiraent.cms.gov/browse/BATIAI-166)

## Description
**main.tf**

- gitlab-runner nodegroup added with node taint registration to disallow non gitlab runner pods from being scheduled
- rolearn added add new node group to the cluster
