### PR TITLE
bumps aws provider to 4.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.56"
+      version = ">= 4.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
# [Issue 281](https://jiraent.cms.gov/browse/BATIAI-281)
Bumps TF AWS provider to 4.0