### PR TITLE
BATIAI-195: Fixing eks ami regex to use the latest image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
 
 data "aws_ami" "eks_ami" {
   most_recent = true
-  name_regex  = "^amzn2-eks-gi-1.21"
+  name_regex  = "^amzn2-eks-1.21-"
   owners      = ["743302140042"]
 }
 


### PR DESCRIPTION
Jira ticket [BATIAI-195](https://jiraent.cms.gov/browse/BATIAI-195)