### PR TITLE
BATIAI-193 - restrict kms permissions

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -8,7 +8,7 @@ data "aws_iam_policy_document" "node_policy" {
   statement {
     sid = "K8sNodes"
     actions = [
-      "kms:*",
+      "kms:Decrypt",
     ]
     resources = [
       data.aws_kms_alias.sops.arn,


### PR DESCRIPTION
[BATIAI-193](https://jiraent.cms.gov/browse/BATIAI-193)

Restricting `kms:*` to `kms:Decrypt`

This is the only action I have seen the nodes perform to KMS.