### PR TITLE
Added the private ALB security group id to the outputs.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -223,6 +223,11 @@ output "batcave_lb_dns" {
   value       = aws_lb.batcave_alb.dns_name
 }
 
+output "private_alb_security_group_id" {
+  description = "The Security Group that controls access to the private ALB"
+  value       = aws_security_group.batcave_alb.id
+}
+
 output "batcave_alb_proxy_dns" {
   description = "DNS value of NLB created for proxying requests through the application load balancer"
   value       = var.create_alb_proxy ? aws_lb.batcave_alb_proxy[0].dns_name : ""


### PR DESCRIPTION
This is needed for the emm-healthcheck lambda deployment so that we can
grant access to the lambda by adding a rule to this security group.