### PR TITLE
Made the list of s3 buckets to grant the cluster access to dynamically configurable.

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -51,12 +51,17 @@ data "aws_iam_policy_document" "node_policy" {
     actions = [
       "s3:ListBucket"
     ]
-    resources = [
-      "arn:aws:s3:::${var.cluster_name}*velero-storage",
-      "arn:aws:s3:::batcave*runner-cache",
-      "arn:aws:s3:::batcave*gitlab*",
-      "arn:aws:s3:::rapidfort*storage"
-    ]
+    resources = (var.s3_bucket_access_grants == null ?
+      # Use legacy default
+      [
+        "arn:aws:s3:::${var.cluster_name}*velero-storage",
+        "arn:aws:s3:::batcave*runner-cache",
+        "arn:aws:s3:::batcave*gitlab*",
+        "arn:aws:s3:::rapidfort*storage"
+      ] :
+      [
+        for bucket in var.s3_bucket_access_grants : "arn:aws:s3:::${bucket}"
+      ])
   }
   statement {
     actions = [
@@ -66,12 +71,17 @@ data "aws_iam_policy_document" "node_policy" {
       "s3:AbortMultipartUpload",
       "s3:List*"
     ]
-    resources = [
-      "arn:aws:s3:::${var.cluster_name}*velero-storage/*",
-      "arn:aws:s3:::batcave*runner-cache/*",
-      "arn:aws:s3:::batcave*gitlab*/*",
-      "arn:aws:s3:::rapidfort*storage/*"
-    ]
+    resources = (var.s3_bucket_access_grants == null ?
+      # Use legacy default
+      [
+        "arn:aws:s3:::${var.cluster_name}*velero-storage/*",
+        "arn:aws:s3:::batcave*runner-cache/*",
+        "arn:aws:s3:::batcave*gitlab*/*",
+        "arn:aws:s3:::rapidfort*storage/*"
+      ] :
+      [
+        for bucket in var.s3_bucket_access_grants : "arn:aws:s3:::${bucket}/*"
+      ])
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -283,3 +283,8 @@ variable "alb_deletion_protection" {
   default     = false
   type        = bool
 }
+variable "s3_bucket_access_grants" {
+  description = "A list of s3 bucket names to grant the cluster roles R/W access to"
+  default     = null
+  type        = list(string)
+}


### PR DESCRIPTION
loki doesn't work in the dev environment, and is hard to get working by default. I'm trying to make that easier. Hard coding a list of bucket wildcards in this terraform code seems problematic. It needs to be modified regularly to keep it in sync with the requirements of `batcave-landing-zone`. This change alleviates that pain point.