### PR TITLE
Batiai-411 Adds access logging for load balancers

### DIFF
--- a/alb-private-to-k8s.tf
+++ b/alb-private-to-k8s.tf
@@ -14,7 +14,7 @@ resource "aws_lb" "batcave_alb" {
   }
 
   access_logs {
-    bucket  = "cms-cloud-${data.aws_caller_identity.current.account_id}-${var.region}"
+    bucket  = var.logging_bucket
     enabled = true
   }
 

--- a/alb-public-to-k8s.tf
+++ b/alb-public-to-k8s.tf
@@ -18,7 +18,7 @@ resource "aws_lb" "batcave_alb_proxy" {
   enable_deletion_protection = var.alb_deletion_protection
 
   access_logs {
-    bucket  = "cms-cloud-${data.aws_caller_identity.current.account_id}-${var.region}"
+    bucket  = var.logging_bucket
     enabled = true
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -328,3 +328,9 @@ variable "s3_bucket_access_grants" {
   default     = null
   type        = list(string)
 }
+
+variable "logging_bucket" {
+  description = "Name of the S3 bucket to send load balancer access logs."
+  default     = null
+  type        = string
+}


### PR DESCRIPTION
https://jiraent.cms.gov/browse/BATIAI-411

Adds access logging to load balancers for various ARS controls.

Requires PR on blz: https://github.com/CMSgov/batcave-landing-zone/pull/407