### PR TITLE
cni image variable added to EKS cluster CNI add-on BATIAI-1020

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -159,7 +159,7 @@ module "eks" {
     vpc-cni = {
       resolve_conflicts        = "OVERWRITE"
       service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
-      addon_version            = var.cni_image
+      addon_version            = var.addon_vpc_cni_version
     }
   }
   # Worker groups (using Launch Configurations)

--- a/variables.tf
+++ b/variables.tf
@@ -290,8 +290,8 @@ variable "ami_regex_override" {
   default     = ""
   type        = string
 }
-variable "cni_image" {
-  description = "This is the image of the CNI pod used in addon"
+variable "addon_vpc_cni_version" {
+  description = "This is the image of the CNI pod used in the vpc-cni addon.  For other options, run: aws eks describe-addon-versions --add"
   default     = "v1.11.4-eksbuild.1"
   string      = string
 }


### PR DESCRIPTION
## Fixes Issue: https://jiraent.cms.gov/browse/BATIAI-1020

## Description: we implemented the VPC-CNI add-on on our cluster but we need to have control over the image of the CNI pod running in kube-system. 


## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [x ] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
