### PR TITLE
BO 2530 Add ALB Timeout and new default

### DIFF
--- a/alb-private-to-k8s.tf
+++ b/alb-private-to-k8s.tf
@@ -7,7 +7,7 @@ resource "aws_lb" "batcave_alb" {
   enable_deletion_protection = var.alb_deletion_protection
   drop_invalid_header_fields = var.alb_drop_invalid_header_fields
 
-  idle_timeout = var.alb_proxy_idle_timeout
+  idle_timeout = var.alb_idle_timeout
 
   dynamic "subnet_mapping" {
     for_each = var.alb_subnets_by_zone

--- a/alb-public-to-k8s.tf
+++ b/alb-public-to-k8s.tf
@@ -18,7 +18,7 @@ resource "aws_lb" "batcave_alb_proxy" {
   enable_deletion_protection = var.alb_deletion_protection
   drop_invalid_header_fields = var.alb_drop_invalid_header_fields
 
-  idle_timeout = var.alb_proxy_idle_timeout
+  idle_timeout = var.alb_idle_timeout
 
   access_logs {
     bucket  = var.logging_bucket

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   name            = var.cluster_name
   cluster_version = var.cluster_version
   region          = var.region
-  alb_proxy_idle_timeout = var.alb_proxy_idle_timeout
+  alb_idle_timeout = var.alb_idle_timeout
 }
 
 data "aws_ami" "eks_ami" {

--- a/variables.tf
+++ b/variables.tf
@@ -248,7 +248,7 @@ variable "alb_drop_invalid_header_fields" {
   type        = bool
 }
 
-variable "alb_proxy_idle_timeout" {
+variable "alb_idle_timeout" {
   description = "Default idle request timeout for the ALB"
   default     = "60"
   type        = string


### PR DESCRIPTION
## Fixes Issue: https://jiraent.cms.gov/browse/BO-2530

## Description:
We have recently improved the performance of Grafana, Loki, and Fluentbit, in separate tickets that have been approved and merged. One adjustment was to increase the default timeout values to be consistently 600 seconds. This update adds support to pass in an alb proxy timeout value, which will be used in both the private and public ALB. The default is still 60 seconds, but making this change allows the batcave-landing-zone, to pass in via variable, and override value.

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [ x] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
