### PR TITLE
removes secretsmanager policy

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -100,38 +100,6 @@ resource "aws_iam_role_policy_attachment" "additional" {
   role       = each.value.iam_role_name
 }
 
-# Secrets Manager policy
-resource "aws_iam_policy" "secretsmanager_policy" {
-  name        = "${local.name}-secretsmanager-policy"
-  path        = var.iam_role_path
-  description = "IAM policy to access secretsm manager"
-  policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Sid" : "secretsfullaccess",
-        "Action" : [
-          "secretsmanager:ListSecrets",
-          "secretsmanager:GetResourcePolicy",
-          "secretsmanager:GetSecretValue",
-          "secretsmanager:DescribeSecret",
-          "secretsmanager:ListSecretVersionIds"
-        ],
-        "Effect" : "Allow",
-        "Resource" : "*"
-      }
-    ]
-  })
-}
-
-# Attach secretsmanager policy to node IAM role
-resource "aws_iam_role_policy_attachment" "secretsmanager" {
-  for_each   = module.eks.self_managed_node_groups
-  policy_arn = aws_iam_policy.secretsmanager_policy.arn
-  role       = each.value.iam_role_name
-}
-
-
 # Cloudwatch Logs policy
 data "aws_iam_policy_document" "cloudwatch_logs" {
   statement {


### PR DESCRIPTION
## Description:
- Removes secretsmanager policy
- Tested by running `tg plan` against prod and verifying the secretsmanager policy and node group attachment would be deleted

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [X] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [ ] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
- Mitigates the risk of nodes accessing secrets they shouldn't have access to