### PR TITLE
BATIAI-1612 - Limiting gitlab runners to one IMDSv2 hop

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="input_transport_proxy_static_ip"></a> [transport\_proxy\_static\_ip](#input\_transport\_proxy\_static\_ip) | n/a | `bool` | `true` | no |
 | <a name="input_volume_tag"></a> [volume\_tag](#input\_volume\_tag) | Volume custom tag | `map(any)` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | n/a | `any` | n/a | yes |
+| <a name="input_enable_hoplimit"></a> [enable\_hoplimit](#enable\_hoplimit) | Boolean to enable a IMDSv2 hop limit of 1 on all nodes. Defaults to false | `bool` | `false` | no | 
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,9 @@
 locals {
-  name             = var.cluster_name
-  cluster_version  = var.cluster_version
-  region           = var.region
-  alb_idle_timeout = var.alb_idle_timeout
+  name              = var.cluster_name
+  cluster_version   = var.cluster_version
+  region            = var.region
+  alb_idle_timeout  = var.alb_idle_timeout
+  hoplimit_metadata = var.enable_hoplimit ? { http_put_response_hop_limit = 1 } : {}
 }
 
 data "aws_ami" "eks_ami" {
@@ -60,6 +61,8 @@ locals {
     ) : null
 
     tags = merge(var.tags, var.instance_tags, try(v.tags, null))
+
+    metadata_options = merge(local.hoplimit_metadata, try(v.metadata_options, {}))
 
     ## Tags that are applied _ONLY_ to the ASG resource and not propagated to the nodes
     ## All the "tags" var will be applied to both ASG and Propagated out to the nodes

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,7 @@ variable "general_node_pool" {
 variable "custom_node_pools" {
   type    = any
   default = {}
+  metadata_options = {}
   #  runners = {
   #    instance_type = "c4.xlarge"
   #    desired_size = 1
@@ -379,4 +380,10 @@ variable "node_schedule_timezone" {
   type        = string
   default     = "America/New_York"
   description = "The timezone of the schedule. Ex: 'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles', 'Pacific/Honolulu'  See: https://www.joda.org/joda-time/timezones.html"
+}
+
+variable "enable_hoplimit" {
+  type        = bool
+  default     = false
+  description = "Enables a IMDSv2 hop limit of 1 on all nodes. Defaults to false"
 }


### PR DESCRIPTION
## Fixes Issue: https://jiraent.cms.gov/browse/BATIAI-1612

## Description:


## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [x] Is there an impact on any other security-related procedures or capabilities?
-  [ ] No security impacts identified.

Security Risks Identified - This increases the security of Gitlab Runner EC2 instances.

Linked to 
https://github.com/CMS-Enterprise/batcave-landing-zone/pull/1277
