### PR TITLE
updated configmap and ingress for cidr blocks

### DIFF
--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -5,15 +5,15 @@ provider "kubernetes" {
 }
 
 locals {
-  static_master_roles = ["aolytix-role", "batcave-github-actions-role"]
+  static_master_roles = ["aolytix-role", "${var.github_actions_role}", "${var.federated_access_role}"]
   merged_master_roles = concat(local.static_master_roles, var.configmap_custom_roles)
   custom_configmap_master_roles = (length(local.merged_master_roles) > 0 ? ([
-  for custom_iam_role_name in local.merged_master_roles : {
-    rolearn  = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${custom_iam_role_name}"
-    username = custom_iam_role_name,
-    groups   = ["system:masters"]
-  }
-  ]) :
+    for custom_iam_role_name in local.merged_master_roles : {
+      rolearn  = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${custom_iam_role_name}"
+      username = custom_iam_role_name,
+      groups   = ["system:masters"]
+    }
+    ]) :
   [])
 }
 

--- a/main.tf
+++ b/main.tf
@@ -226,6 +226,7 @@ resource "null_resource" "kubernetes_requirements" {
     aws_security_group_rule.allow_ingress_additional_prefix_lists,
     aws_security_group_rule.allow_all_nodes_to_other_nodes,
     aws_security_group_rule.https-tg-ingress,
+    aws_security_group_rule.https-vpc-ingress,
   ]
 }
 
@@ -323,6 +324,17 @@ resource "aws_security_group_rule" "https-tg-ingress" {
   security_group_id = module.eks.node_security_group_id
   cidr_blocks       = ["10.0.0.0/8"]
 }
+
+resource "aws_security_group_rule" "https-vpc-ingress" {
+  count             = length(var.vpc_cidr_blocks) > 0 ? 1 : 0
+  type              = "ingress"
+  to_port           = 443
+  from_port         = 0
+  protocol          = "tcp"
+  security_group_id = module.eks.cluster_primary_security_group_id
+  cidr_blocks       = var.vpc_cidr_blocks
+}
+
 
 ## Setup for cosign keyless signatures
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -381,7 +381,26 @@ variable "enable_hoplimit" {
 }
 
 variable "configmap_custom_roles" {
-  default = []
+  default     = []
   description = "A custom list of IAM role names to include in the aws-auth configmap"
-  type = list(string)
+  type        = list(string)
+}
+
+variable "vpc_cidr_blocks" {
+  description = "List of VPC CIDR blocks"
+  type        = list(string)
+}
+
+variable "github_actions_role" {
+  type        = string
+  default     = "batcave-github-actions-role"
+  description = "Github actions role"
+}
+
+### Federated role will be added to the ConfigMap so that the users can have access to the Kubernetes objects of the cluster.
+### By default the users will not have access when the cluster is created by GitHub runner.
+variable "federated_access_role" {
+  type        = string
+  default     = "ct-ado-batcave-application-admin"
+  description = "Federated access role"
 }


### PR DESCRIPTION
## Fixes Issue: [BATIAI-1778 Update ADO template and workflow](https://jiraent.cms.gov/browse/BATIAI-1778)

## Description:
Updates the following
- Creates https ingress for VPC CIDRs
- Creates ConfigMap for Federated role
- Updates ConfigMap for GitHub runner role
- Defaults Federated and GitHub runner roles to the batcave-dev values
- Updates variables for the above

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [X] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
