### PR TITLE
BATIAI-1814 - Adds default value for vpc_cidr_blocks to prevent prompt

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -387,6 +387,7 @@ variable "configmap_custom_roles" {
 }
 
 variable "vpc_cidr_blocks" {
+  default = []
   description = "List of VPC CIDR blocks"
   type        = list(string)
 }


### PR DESCRIPTION
## Fixes Issue: [BATIAI-1814](https://jiraent.cms.gov/browse/BATIAI-1814)

## Description:

Adds a default empty list for the vpc_cidr_blocks to prevent prompt when creating a new cluster

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [x] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
