### PR TITLE
fix: only allow tls 1.2 and greater on albs

### DIFF
--- a/alb-private-to-k8s.tf
+++ b/alb-private-to-k8s.tf
@@ -32,6 +32,7 @@ resource "aws_lb_listener" "batcave_alb_https" {
   load_balancer_arn = aws_lb.batcave_alb.arn
   port              = "443"
   protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.batcave_alb_https.arn

--- a/alb-public-to-k8s.tf
+++ b/alb-public-to-k8s.tf
@@ -38,6 +38,7 @@ resource "aws_lb_listener" "batcave_alb_proxy_https" {
   load_balancer_arn = aws_lb.batcave_alb_proxy[0].arn
   port              = "443"
   protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.batcave_alb_proxy_https[0].arn

--- a/alb-shared-to-k8s.tf
+++ b/alb-shared-to-k8s.tf
@@ -31,6 +31,7 @@ resource "aws_lb_listener" "batcave_alb_shared_https" {
   load_balancer_arn = aws_lb.batcave_alb_shared[0].arn
   port              = "443"
   protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.batcave_alb_shared_https[0].arn


### PR DESCRIPTION
## Fixes Issue: TLS 1.0/1.1 findings

## Description:

This change enables the `ELBSecurityPolicy-TLS13-1-2-2021-06` security policy on our ALBs, which will resolve the findings generated for TLS 1.0/1.1 being allowed on our public facing endpoints. 

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies


## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [X] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [ ] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.

No additional risk introduced. These changes mitigate risks associated with deprecated TLS versions

