### PR TITLE
BATIAI-2314: Configure deny by default for the shared ALB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 14.1.0
+
+* security: Change the default Shared ALB configuration to deny access by default until the allowed hostnames are configured
+
 ## 14.0.1
 
 * bugfix: Pin vpc_cni_irsa module to 5.33 to avoid breaking aws provider change

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 1.14.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.31.0 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 1.14.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.25.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
 
 ## Modules
 
@@ -152,7 +152,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="input_alb_shared_ingress_cidrs"></a> [alb\_shared\_ingress\_cidrs](#input\_alb\_shared\_ingress\_cidrs) | List of CIDR blocks allowed to access the ALB Proxy; used to restrict public access to a certain set of IPs | `list(string)` | `[]` | no |
 | <a name="input_alb_shared_ingress_prefix_lists"></a> [alb\_shared\_ingress\_prefix\_lists](#input\_alb\_shared\_ingress\_prefix\_lists) | List of Prefix List IDs allowed to access the ALB Proxy; used to restrict public access to a certain set of IPs | `list(string)` | `[]` | no |
 | <a name="input_alb_shared_is_internal"></a> [alb\_shared\_is\_internal](#input\_alb\_shared\_is\_internal) | If the ALB in the shared subnet should be using internal ips. Defaults to false, because the reason for this ALB existing is to make it accessible over the Internet | `bool` | `false` | no |
-| <a name="input_alb_shared_restricted_hosts"></a> [alb\_shared\_restricted\_hosts](#input\_alb\_shared\_restricted\_hosts) | A list of allowable host for shared alb | `set(string)` | `[]` | no |
+| <a name="input_alb_shared_restricted_hosts"></a> [alb\_shared\_restricted\_hosts](#input\_alb\_shared\_restricted\_hosts) | A list of allowable host for shared alb. Defaults to deny to ensure this load balancer is configured correctly. | `set(string)` | <pre>[<br>  "deny-by-default.example.com"<br>]</pre> | no |
 | <a name="input_alb_shared_subnets"></a> [alb\_shared\_subnets](#input\_alb\_shared\_subnets) | List of subnet ids for the ALB in the shared subnet | `list(string)` | `[]` | no |
 | <a name="input_alb_ssl_security_policy"></a> [alb\_ssl\_security\_policy](#input\_alb\_ssl\_security\_policy) | ALB SSL Security Policy | `string` | `"ELBSecurityPolicy-TLS13-1-2-Res-2021-06"` | no |
 | <a name="input_alb_subnets_by_zone"></a> [alb\_subnets\_by\_zone](#input\_alb\_subnets\_by\_zone) | n/a | `map(string)` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.31.0 |
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | 1.14.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.25.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 1.14.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
 ## Modules
 

--- a/alb-shared-to-k8s.tf
+++ b/alb-shared-to-k8s.tf
@@ -45,7 +45,10 @@ resource "aws_lb_listener" "batcave_alb_shared_https" {
       type = "fixed-response"
       fixed_response {
         content_type = "text/plain"
-        message_body = "Unacceptable Host"
+        # This load balancer is configured to deny all access by default.
+        # In this default configuration, the error message will indicate they
+        # need to come to the infrastructure team for help.
+        message_body = var.alb_shared_restricted_hosts[0] == "deny-by-default.example.com" ? "Misconfigured load balancer.  Contact infrstructure team for assistance." : "Unacceptable Host"
         status_code  = "403"
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -128,8 +128,8 @@ variable "alb_proxy_restricted_hosts" {
 }
 variable "alb_shared_restricted_hosts" {
   type        = set(string)
-  description = "A list of allowable host for shared alb"
-  default     = []
+  description = "A list of allowable host for shared alb. Defaults to deny to ensure this load balancer is configured correctly."
+  default     = ["deny-by-default.example.com"]
 }
 variable "create_alb_proxy" {
   type        = bool


### PR DESCRIPTION
## Fixes Issue: [BATIAI-2314](https://jiraent.cms.gov/browse/BATIAI-2314)

## Description:


## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [x] Is there an impact on Communication Security procedures or capabilities?
  - Configures a deny-by-default stance for our Public load balancers until an engineer explicitly states what domains are valid.
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [ ] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.