### PR TITLE
BATIAI-2353 eks module update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Launch template with managed groups example
+# Launch template with managed groups example  
 
 This is EKS example using workers custom launch template with managed groups feature in two different ways:
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="input_alb_ssl_security_policy"></a> [alb\_ssl\_security\_policy](#input\_alb\_ssl\_security\_policy) | ALB SSL Security Policy | `string` | `"ELBSecurityPolicy-TLS13-1-2-Res-2021-06"` | no |
 | <a name="input_alb_subnets_by_zone"></a> [alb\_subnets\_by\_zone](#input\_alb\_subnets\_by\_zone) | n/a | `map(string)` | n/a | yes |
 | <a name="input_ami_date"></a> [ami\_date](#input\_ami\_date) | n/a | `string` | `""` | no |
-| <a name="input_ami_owner_override"></a> [ami\_owner\_override](#input\_ami\_owner\_override) | Override the AWS Account owner used to look up AMI's for the cluster nodes | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_ami_owner_override"></a> [ami\_owner\_override](#input\_ami\_owner\_override) | Override the AWS Account owner used to look up AMI's for the cluster nodes | `string` | `""` | no |
 | <a name="input_ami_regex_override"></a> [ami\_regex\_override](#input\_ami\_regex\_override) | Overrides default AMI lookup regex, which grabs latest AMI matching cluster\_version by default | `string` | `""` | no |
 | <a name="input_bottlerocket_pod_pids_limit"></a> [bottlerocket\_pod\_pids\_limit](#input\_bottlerocket\_pod\_pids\_limit) | The maximum number of processes that can be created in a pod | `number` | `1000` | no |
 | <a name="input_cluster_additional_sg_prefix_lists"></a> [cluster\_additional\_sg\_prefix\_lists](#input\_cluster\_additional\_sg\_prefix\_lists) | n/a | `list(string)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -52,10 +52,6 @@ locals {
 # EKS Fully managed nodes
 ################################################################################
 locals {
-  volume_size                  = try(var.node_volume_size, 300)
-  volume_type                  = try(var.node_volume_type, "gp3")
-  volume_delete_on_termination = try(var.node_volume_delete_on_termination, true)
-
   base_block_device_mappings = [
     {
       device_name = "/dev/xvda"
@@ -69,9 +65,9 @@ locals {
     {
       device_name = "/dev/xvdb"
       ebs = {
-        volume_size           = try(local.volume_size, "300")
-        volume_type           = try(local.volume_type, "gp3")
-        delete_on_termination = try(local.volume_delete_on_termination, true)
+        volume_size           = var.node_volume_size
+        volume_type           = var.node_volume_type
+        delete_on_termination = var.node_volume_delete_on_termination
         encrypted             = true
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ locals {
     block_device_mappings = local.is_bottlerocket_ami ? [
       for index, block_device in v.base_block_device_mappings :
         index > 0 ? {
-          device_name = idx == 1 ? "/dev/xvda" : block_device.device_name
+          device_name = index == 1 ? "/dev/xvda" : block_device.device_name
           ebs = block_device.ebs
         } : null
     ] : v.base_block_device_mappings

--- a/main.tf
+++ b/main.tf
@@ -124,17 +124,11 @@ locals {
     desired_size = v.desired_size
 
     # This is dynamically creating the block device mappings based on the AMI type
-    block_device_mappings = local.is_bottlerocket_ami ? [
+    block_device_mappings = local.is_bottlerocket_ami ? local.base_block_device_mappings :
     {
       device_name = "/dev/xvda"
-      ebs = {
-        volume_size           = var.node_volume_size
-        volume_type           = var.node_volume_type
-        delete_on_termination = var.node_volume_delete_on_termination
-        encrypted             = true
-      }
+      ebs = local.base_block_device_mappings[1].ebs
     }
-  ] : local.base_block_device_mappings
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -7,8 +7,8 @@ locals {
 
 data "aws_ami" "eks_ami" {
   most_recent = true
-  name_regex  = var.ami_regex_override == "" ? "^bottlerocket-aws-k8s-1.27-x86_64-v1.17.0" : var.ami_regex_override
-  owners      = ["092701018921"]
+  name_regex  = var.use_bottlerocket ? "^bottlerocket-aws-k8s-${var.cluster_version}-x86_64-v1.17.0" : (var.ami_regex_override == "" ? "^amzn2-eks-${var.cluster_version}-gi-${var.ami_date}" : var.ami_regex_override)
+  owners      = var.use_bottlerocket ? ["092701018921"] : (var.ami_owner_override == [""] ? ["743302140042"] : var.ami_owner_override)
 }
 
 data "aws_security_groups" "delete_ebs_volumes_lambda_security_group" {

--- a/main.tf
+++ b/main.tf
@@ -48,13 +48,13 @@ locals {
 ################################################################################
 locals {
   shared_node_labels = {
-    for k, v in var.custom_node_pools : k => {
+    for k, v in merge({ general = var.general_node_pool }, var.custom_node_pools) : k => {
       for label_key, label_value in try(v.labels, {}) : label_key => label_value
     }
   }
 
   shared_node_taints = {
-    for k, v in var.custom_node_pools : k => [
+    for k, v in merge({ general = var.general_node_pool }, var.custom_node_pools) : k => [
       for taint_key, taint_string in try(v.taints, {}) : {
         key    = taint_key
         value  = element(split(":", taint_string), 0)

--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ locals {
           volume_size           = 8
           volume_type           = "gp3"
           delete_on_termination = true
+          encrypted             = true
         }
       },
       {
@@ -98,6 +99,7 @@ locals {
           volume_size           = try(v.volume_size, "300")
           volume_type           = try(v.volume_type, "gp3")
           delete_on_termination = try(v.delete_on_termination, true)
+          encrypted             = true
         }
       }
       ] : [
@@ -107,6 +109,7 @@ locals {
           volume_size           = try(v.volume_size, "300")
           volume_type           = try(v.volume_type, "gp3")
           delete_on_termination = try(v.delete_on_termination, true)
+          encrypted             = true
         }
       }
     ]

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,8 @@ locals {
 data "aws_ami" "eks_ami" {
   most_recent = true
   name_regex  = var.use_bottlerocket ? "^bottlerocket-aws-k8s-${var.cluster_version}-x86_64-v1.17.0" : (var.ami_regex_override == "" ? "^amzn2-eks-${var.cluster_version}-gi-${var.ami_date}" : var.ami_regex_override)
-  owners      = var.use_bottlerocket ? ["092701018921"] : (length(var.ami_owner_override) > 0 && var.ami_owner_override[0] != "" ? var.ami_owner_override : ["743302140042"])
+  # If an ami_owner_override is provided, use it.  Otherwise use the AWS AMI's for bottlerocket, and CMS AMIs AL2
+  owners      = var.ami_owner_override != "" ? [var.ami_owner_override] : (var.use_bottlerocket ? ["092701018921"] : ["743302140042"])
 }
 
 data "aws_security_groups" "delete_ebs_volumes_lambda_security_group" {

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ data "aws_ami" "eks_ami" {
   most_recent = true
   name_regex  = var.use_bottlerocket ? "^bottlerocket-aws-k8s-${var.cluster_version}-x86_64-v1.17.0" : (var.ami_regex_override == "" ? "^amzn2-eks-${var.cluster_version}-gi-${var.ami_date}" : var.ami_regex_override)
   # If an ami_owner_override is provided, use it.  Otherwise use the AWS AMI's for bottlerocket, and CMS AMIs AL2
-  owners      = var.ami_owner_override != "" ? [var.ami_owner_override] : (var.use_bottlerocket ? ["092701018921"] : ["743302140042"])
+  owners = var.ami_owner_override != "" ? [var.ami_owner_override] : (var.use_bottlerocket ? ["092701018921"] : ["743302140042"])
 }
 
 data "aws_security_groups" "delete_ebs_volumes_lambda_security_group" {

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ locals {
     {
       device_name = "/dev/xvda"
       ebs = {
-        volume_size           = "5"
+        volume_size           = "8"
         volume_type           = "gp3"
         delete_on_termination = true
         encrypted             = true
@@ -123,13 +123,18 @@ locals {
     max_size     = v.max_size
     desired_size = v.desired_size
 
+    # This is dynamically creating the block device mappings based on the AMI type
     block_device_mappings = local.is_bottlerocket_ami ? [
-      for index, block_device in local.base_block_device_mappings :
-        index > 0 ? {
-          device_name = index == 1 ? "/dev/xvda" : block_device.device_name
-          ebs = block_device.ebs
-        } : null
-    ] : local.base_block_device_mappings
+    {
+      device_name = "/dev/xvda"
+      ebs = {
+        volume_size           = var.node_volume_size
+        volume_type           = var.node_volume_type
+        delete_on_termination = var.node_volume_delete_on_termination
+        encrypted             = true
+      }
+    }
+  ] : local.base_block_device_mappings
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
 data "aws_ami" "eks_ami" {
   most_recent = true
   name_regex  = var.use_bottlerocket ? "^bottlerocket-aws-k8s-${var.cluster_version}-x86_64-v1.17.0" : (var.ami_regex_override == "" ? "^amzn2-eks-${var.cluster_version}-gi-${var.ami_date}" : var.ami_regex_override)
-  owners      = var.use_bottlerocket ? ["092701018921"] : ["743302140042"]
+  owners      = var.use_bottlerocket ? ["092701018921"] : (length(var.ami_owner_override) > 0 && var.ami_owner_override[0] != "" ? var.ami_owner_override : ["743302140042"])
 }
 
 data "aws_security_groups" "delete_ebs_volumes_lambda_security_group" {

--- a/main.tf
+++ b/main.tf
@@ -75,9 +75,9 @@ locals {
 
   eks_node_pools = { for k, v in merge({ general = var.general_node_pool }, var.custom_node_pools) : k => {
     group_name      = k
-    name            = "${var.cluster_name}-${k}"
-    cluster_name    = local.name
-    cluster_version = local.cluster_version
+    name            = "${module.eks.cluster_name}-${k}"
+    cluster_name    = module.eks.cluster_name
+    cluster_version = module.eks.cluster_version
 
     iam_role_path                 = var.iam_role_path
     iam_role_permissions_boundary = var.iam_role_permissions_boundary
@@ -89,6 +89,16 @@ locals {
     ami_type                   = var.platform == "bottlerocket" ? "BOTTLEROCKET_x86_64" : "AL2_x86_64"
     platform                   = try(var.platform, "linux")
     bootstrap_extra_args       = <<-EOT
+      # Base settings for bottlerocket
+      [settings.kubernetes]
+      cluster-name = "${module.eks.cluster_name}"
+      api-server = "${module.eks.cluster_endpoint}"
+      cluster-certificate = "${module.eks.cluster_certificate_authority_data}"
+
+      # Set autoscaling wait
+      [settings.autoscaling]
+      should-wait = true
+
       # settings.kubernetes section from bootstrap_extra_args in default template
       pod-pids-limit = 1000
 

--- a/main.tf
+++ b/main.tf
@@ -464,7 +464,7 @@ resource "aws_iam_role" "cosign" {
 #}
 
 resource "aws_autoscaling_attachment" "eks_managed_node_groups_alb_attachment" {
-  for_each               = var.enable_eks_managed_nodes ? { for np in local.eks_node_pools : np.name => np } : {}
+  for_each               = { for np in local.eks_node_pools : np.name => np }
   autoscaling_group_name = try(module.eks_managed_node_groups[each.value.group_name].node_group_autoscaling_group_names[0], "")
 
   lb_target_group_arn = aws_lb_target_group.batcave_alb_https.arn
@@ -475,7 +475,7 @@ resource "aws_autoscaling_attachment" "eks_managed_node_groups_alb_attachment" {
 }
 
 resource "aws_autoscaling_attachment" "eks_managed_node_groups_proxy_attachment" {
-  for_each               = var.create_alb_proxy && var.enable_eks_managed_nodes ? { for np in local.eks_node_pools : np.name => np } : {}
+  for_each               = var.create_alb_proxy ? { for np in local.eks_node_pools : np.name => np } : {}
   autoscaling_group_name = try(module.eks_managed_node_groups[each.value.group_name].node_group_autoscaling_group_names[0], "")
 
   lb_target_group_arn = var.create_alb_proxy ? aws_lb_target_group.batcave_alb_proxy_https[0].arn : null
@@ -486,7 +486,7 @@ resource "aws_autoscaling_attachment" "eks_managed_node_groups_proxy_attachment"
 }
 
 resource "aws_autoscaling_attachment" "eks_managed_node_groups_shared_attachment" {
-  for_each               = var.create_alb_shared && var.enable_eks_managed_nodes ? { for np in local.eks_node_pools : np.name => np } : {}
+  for_each               = var.create_alb_shared ? { for np in local.eks_node_pools : np.name => np } : {}
   autoscaling_group_name = try(module.eks_managed_node_groups[each.value.group_name].node_group_autoscaling_group_names[0], "")
 
   lb_target_group_arn = var.create_alb_shared ? aws_lb_target_group.batcave_alb_shared_https[0].arn : null

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ locals {
         }
       },
       {
-        device_name = "dev/xvdb"
+        device_name = "/dev/xvdb"
         ebs = {
           volume_size           = try(v.volume_size, "300")
           volume_type           = try(v.volume_type, "gp3")

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
 data "aws_ami" "eks_ami" {
   most_recent = true
   name_regex  = var.use_bottlerocket ? "^bottlerocket-aws-k8s-${var.cluster_version}-x86_64-v1.17.0" : (var.ami_regex_override == "" ? "^amzn2-eks-${var.cluster_version}-gi-${var.ami_date}" : var.ami_regex_override)
-  owners      = var.use_bottlerocket ? ["092701018921"] : (var.ami_owner_override == [""] ? ["743302140042"] : var.ami_owner_override)
+  owners      = var.use_bottlerocket ? ["092701018921"] : ["743302140042"]
 }
 
 data "aws_security_groups" "delete_ebs_volumes_lambda_security_group" {

--- a/main.tf
+++ b/main.tf
@@ -185,6 +185,7 @@ locals {
       # extra args added
       [settings.kernel]
       lockdown = "integrity"
+      user.max_user_namespaces = "10000"
 
       [settings.kubernetes.node-labels]
       # label1 = "foo"

--- a/main.tf
+++ b/main.tf
@@ -99,8 +99,8 @@ locals {
 
     # Added for Bottlerocket
     use_custom_launch_template = try(v.use_custom_launch_template, true)
-    ami_type                   = var.platform == "bottlerocket" ? "BOTTLEROCKET_x86_64" : "AL2_x86_64"
-    platform                   = try(var.platform, "linux")
+    ami_type                   = var.use_bottlerocket ? "BOTTLEROCKET_x86_64" : "AL2_x86_64"
+    platform                   = var.use_bottlerocket ? "bottlerocket" : "linux"
     bootstrap_extra_args       = local.bottlerocket_bootstrap_template
 
     subnet_ids = coalescelist(try(v.subnet_ids, []), var.host_subnets, var.private_subnets)
@@ -201,10 +201,6 @@ module "eks" {
   cluster_encryption_config = {
     provider_key_arn = aws_kms_key.eks.arn
     resources        = ["secrets"]
-  }
-
-  self_managed_node_group_defaults = {
-    subnet_ids = coalescelist(var.host_subnets, var.private_subnets)
   }
 
   ## CLUSTER Addons

--- a/main.tf
+++ b/main.tf
@@ -124,11 +124,12 @@ locals {
     desired_size = v.desired_size
 
     # This is dynamically creating the block device mappings based on the AMI type
-    block_device_mappings = local.is_bottlerocket_ami ? local.base_block_device_mappings :
-    {
-      device_name = "/dev/xvda"
-      ebs = local.base_block_device_mappings[1].ebs
-    }
+    block_device_mappings = local.is_bottlerocket_ami ? local.base_block_device_mappings : [
+      {
+        device_name = "/dev/xvda"
+        ebs = local.base_block_device_mappings[1].ebs
+      }
+    ]
 
 
 

--- a/templates/bottlerocket.toml.tpl
+++ b/templates/bottlerocket.toml.tpl
@@ -24,7 +24,7 @@ lockdown = "integrity"
 "user.max_user_namespaces" = "${max_namespaces}"
 
 [settings.kubernetes.node-labels]
-${node_labels}
+"${node_labels}"
 
 [settings.kubernetes.node-taints]
-${node_taints}
+"${node_taints}"

--- a/templates/bottlerocket.toml.tpl
+++ b/templates/bottlerocket.toml.tpl
@@ -24,7 +24,11 @@ lockdown = "integrity"
 "user.max_user_namespaces" = "${max_namespaces}"
 
 [settings.kubernetes.node-labels]
-"${node_labels}"
+%{ for label_key, label_value in node_labels ~}
+"${label_key}" = "${label_value}"
+%{ endfor ~}
 
 [settings.kubernetes.node-taints]
-"${node_taints}"
+%{ for taint in node_taints ~}
+"${taint.key}" = "${taint.value}:${taint.effect}"
+%{ endfor ~}

--- a/templates/bottlerocket.toml.tpl
+++ b/templates/bottlerocket.toml.tpl
@@ -1,12 +1,12 @@
 # settings.kubernetes section from bootstrap_extra_args in default template
-pod-pids-limit = 1000
+pod-pids-limit = ${pod_pids_limit}
 
 # Set autoscaling wait
 [settings.autoscaling]
 should-wait = true
 
 # The admin host container provides SSH access and runs with "superpowers".
-# It is disabled by default, but can be disabled explicitly.
+# It is disabled by default, but can be enabled explicitly.
 [settings.host-containers.admin]
 enabled = false
 

--- a/templates/bottlerocket.toml.tpl
+++ b/templates/bottlerocket.toml.tpl
@@ -1,8 +1,3 @@
-[settings.kubernetes]
-cluster-name = "${cluster_name}"
-api-server = "${cluster_endpoint}"
-cluster-certificate = "${cluster_ca_data}"
-
 # Set autoscaling wait
 [settings.autoscaling]
 should-wait = true

--- a/templates/bottlerocket.toml.tpl
+++ b/templates/bottlerocket.toml.tpl
@@ -1,9 +1,9 @@
+# settings.kubernetes section from bootstrap_extra_args in default template
+pod-pids-limit = 1000
+
 # Set autoscaling wait
 [settings.autoscaling]
 should-wait = true
-
-# settings.kubernetes section from bootstrap_extra_args in default template
-pod-pids-limit = 1000
 
 # The admin host container provides SSH access and runs with "superpowers".
 # It is disabled by default, but can be disabled explicitly.

--- a/templates/bottlerocket.toml.tpl
+++ b/templates/bottlerocket.toml.tpl
@@ -1,0 +1,35 @@
+[settings.kubernetes]
+cluster-name = "${cluster_name}"
+api-server = "${cluster_endpoint}"
+cluster-certificate = "${cluster_ca_data}"
+
+# Set autoscaling wait
+[settings.autoscaling]
+should-wait = true
+
+# settings.kubernetes section from bootstrap_extra_args in default template
+pod-pids-limit = 1000
+
+# The admin host container provides SSH access and runs with "superpowers".
+# It is disabled by default, but can be disabled explicitly.
+[settings.host-containers.admin]
+enabled = false
+
+# The control host container provides out-of-band access via SSM.
+# It is enabled by default, and can be disabled if you do not expect to use SSM.
+# This could leave you with no way to access the API and change settings on an existing node!
+[settings.host-containers.control]
+enabled = true
+
+# extra args added
+[settings.kernel]
+lockdown = "integrity"
+
+[settings.kernel.sysctl]
+"user.max_user_namespaces" = "${max_namespaces}"
+
+[settings.kubernetes.node-labels]
+${node_labels}
+
+[settings.kubernetes.node-taints]
+${node_taints}

--- a/templates/bottlerocket.toml.tpl
+++ b/templates/bottlerocket.toml.tpl
@@ -23,12 +23,16 @@ lockdown = "integrity"
 [settings.kernel.sysctl]
 "user.max_user_namespaces" = "${max_namespaces}"
 
+%{ if length(node_labels) > 0 ~}
 [settings.kubernetes.node-labels]
 %{ for label_key, label_value in node_labels ~}
 "${label_key}" = "${label_value}"
 %{ endfor ~}
+%{ endif ~}
 
+%{ if length(node_taints) > 0 ~}
 [settings.kubernetes.node-taints]
 %{ for taint in node_taints ~}
 "${taint.key}" = "${taint.value}:${taint.effect}"
 %{ endfor ~}
+%{ endif ~}

--- a/variables.tf
+++ b/variables.tf
@@ -394,3 +394,15 @@ variable "ssm_tag_patch_window" {
   default     = "ITOPS-Wave1-Non-Mktplc-DevTestImpl-MW"
   description = "SSM Patching window for instances. For more information: https://cloud.cms.gov/patching-prerequisites"
 }
+
+variable "ami_owner_override" {
+  type        = list(string)
+  default     = [""]
+  description = "AMI owner override"
+}
+
+variable "use_bottlerocket" {
+  type        = bool
+  default     = false
+  description = "Use Bottlerocket"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -15,14 +15,21 @@ variable "ami_date" {
 }
 
 ## Default node group
+variable "platform" {
+  default = "bottlerocket"
+  type    = string
+}
+
 variable "general_node_pool" {
   type        = any
   description = "General node pool, required for hosting core services"
   default = {
     instance_type = "c5.2xlarge"
+    # ami_type      = "BOTTLEROCKET_x86_64"
     desired_size  = 3
     max_size      = 5
     min_size      = 2
+    use_custom_launch_template = false
     # Map of label flags for kubelets.
     labels = { general = "true" }
     taints = {}

--- a/variables.tf
+++ b/variables.tf
@@ -406,3 +406,15 @@ variable "use_bottlerocket" {
   default     = false
   description = "Use Bottlerocket"
 }
+
+variable "node_labels" {
+  description = "The labels to apply to the EKS nodes"
+  type        = map(string)
+  default     = {}
+}
+
+variable "node_taints" {
+  description = "The taints to apply to the EKS nodes"
+  type        = map(string)
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -348,8 +348,8 @@ variable "ssm_tag_patch_window" {
 }
 
 variable "ami_owner_override" {
-  type        = list(string)
-  default     = [""]
+  type        = string
+  default     = ""
   description = "Override the AWS Account owner used to look up AMI's for the cluster nodes"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -14,12 +14,6 @@ variable "ami_date" {
   type    = string
 }
 
-## Default node group
-variable "platform" {
-  default = "bottlerocket"
-  type    = string
-}
-
 variable "general_node_pool" {
   type        = any
   description = "General node pool, required for hosting core services"

--- a/variables.tf
+++ b/variables.tf
@@ -122,6 +122,24 @@ variable "node_https_ingress_cidr_blocks" {
   type        = list(string)
 }
 
+variable "node_volume_size" {
+  description = "The size of the volume to use for the nodes.  Defaults to 20"
+  default     = 300
+  type        = number
+}
+
+variable "node_volume_type" {
+  description = "The type of volume to use for the nodes.  Defaults to gp2"
+  default     = "gp3"
+  type        = string
+}
+
+variable "node_volume_delete_on_termination" {
+  description = "Whether the volume should be deleted when the node is terminated.  Defaults to true"
+  default     = true
+  type        = bool
+}
+
 variable "alb_restricted_hosts" {
   type        = set(string)
   description = "A list of allowable host for private alb"

--- a/variables.tf
+++ b/variables.tf
@@ -350,25 +350,13 @@ variable "ssm_tag_patch_window" {
 variable "ami_owner_override" {
   type        = list(string)
   default     = [""]
-  description = "AMI owner override"
+  description = "Override the AWS Account owner used to look up AMI's for the cluster nodes"
 }
 
 variable "use_bottlerocket" {
   type        = bool
   default     = false
   description = "Use Bottlerocket"
-}
-
-variable "node_labels" {
-  description = "The labels to apply to the EKS nodes"
-  type        = map(string)
-  default     = {}
-}
-
-variable "node_taints" {
-  description = "The taints to apply to the EKS nodes"
-  type        = map(string)
-  default     = {}
 }
 
 variable "bottlerocket_pod_pids_limit" {

--- a/variables.tf
+++ b/variables.tf
@@ -18,12 +18,11 @@ variable "general_node_pool" {
   type        = any
   description = "General node pool, required for hosting core services"
   default = {
-    instance_type = "c5.2xlarge"
-    # ami_type      = "BOTTLEROCKET_x86_64"
-    desired_size                 = 3
-    max_size                     = 5
-    min_size                     = 2
-    use_custom_launch_template   = false
+    instance_type              = "c5.2xlarge"
+    desired_size               = 3
+    max_size                   = 5
+    min_size                   = 2
+    use_custom_launch_template = false
     # Map of label flags for kubelets.
     labels = { general = "true" }
     taints = {}
@@ -116,19 +115,19 @@ variable "node_https_ingress_cidr_blocks" {
   type        = list(string)
 }
 
-variable "node_volume_size" {
+variable "node_default_volume_size" {
   description = "The size of the volume to use for the nodes.  Defaults to 20"
   default     = 300
   type        = number
 }
 
-variable "node_volume_type" {
+variable "node_default_volume_type" {
   description = "The type of volume to use for the nodes.  Defaults to gp2"
   default     = "gp3"
   type        = string
 }
 
-variable "node_volume_delete_on_termination" {
+variable "node_default_volume_delete_on_termination" {
   description = "Whether the volume should be deleted when the node is terminated.  Defaults to true"
   default     = true
   type        = bool
@@ -411,4 +410,10 @@ variable "node_taints" {
   description = "The taints to apply to the EKS nodes"
   type        = map(string)
   default     = {}
+}
+
+variable "bottlerocket_pod_pids_limit" {
+  type        = number
+  default     = 1000
+  description = "The maximum number of processes that can be created in a pod"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,10 +26,10 @@ variable "general_node_pool" {
   default = {
     instance_type = "c5.2xlarge"
     # ami_type      = "BOTTLEROCKET_x86_64"
-    desired_size  = 3
-    max_size      = 5
-    min_size      = 2
-    use_custom_launch_template = false
+    desired_size                 = 3
+    max_size                     = 5
+    min_size                     = 2
+    use_custom_launch_template   = false
     # Map of label flags for kubelets.
     labels = { general = "true" }
     taints = {}

--- a/variables.tf
+++ b/variables.tf
@@ -272,16 +272,31 @@ variable "ami_regex_override" {
   default     = ""
   type        = string
 }
+
+variable "node_schedule_shutdown_cron" {
+  type        = string
+  default     = ""
+  description = "The cron schedule for the cluster to be shutdown.  If left empty, the cluster will not be stopped. Will run every day otherwise."
+}
+
+variable "node_schedule_startup_cron" {
+  type        = string
+  default     = ""
+  description = "The cron schedule for the cluster to be restarted.  If left empty, the cluster will not be restarted after shutdown. Will run every weekday otherwise."
+}
+
 variable "node_schedule_shutdown_hour" {
   type        = number
   default     = -1
   description = "The hour of the day (0-23) the cluster should be shutdown.  If left empty, the cluster will not be stopped. Will run every day otherwise."
 }
+
 variable "node_schedule_startup_hour" {
   type        = number
   default     = -1
   description = "The hour of the day (0-23) the cluster should be restarted.  If left empty, the cluster will not be restarted after shutdown. Will run every weekday otherwise."
 }
+
 variable "node_schedule_timezone" {
   type        = string
   default     = "America/New_York"

--- a/variables.tf
+++ b/variables.tf
@@ -326,12 +326,6 @@ variable "enable_self_managed_nodes" {
   description = "Enables self managed nodes"
 }
 
-variable "enable_eks_managed_nodes" {
-  type        = bool
-  default     = false
-  description = "Enables eks managed nodes"
-}
-
 variable "force_update_version" {
   type        = bool
   default     = true


### PR DESCRIPTION
## Fixes Issue: [BATIAI-2353](https://jiraent.cms.gov/browse/BATIAI-2353)

## Description: Updates to remove custom node pools and only support eks managed nodes. Make CMS AMI default with the ability to go to bottlerocket. Dynamic block device assignments based on AMI.


## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [X] No security impacts identified.

Security Risks Identified - N/A
